### PR TITLE
Render inventory UI in stereopsis mode

### DIFF
--- a/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
+++ b/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
@@ -207,7 +207,7 @@ public abstract class MixinInGameHud {
     }
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void moveInventory(DrawContext context, float tickDelta, CallbackInfo ci) {
+    private void moveInventory(DrawContext context, net.minecraft.class_9779 tickDelta, CallbackInfo ci) {
         if (enabled && client.currentScreen != null) {
             ci.cancel();
             Profiler profiler = Profilers.get();

--- a/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
+++ b/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
@@ -206,4 +206,26 @@ public abstract class MixinInGameHud {
         if (enabled) ci.cancel();
     }
 
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+    private void moveInventory(DrawContext context, float tickDelta, CallbackInfo ci) {
+        if (enabled && client.currentScreen != null) {
+            ci.cancel();
+            Profiler profiler = Profilers.get();
+            profiler.push("stereopsis-inventory");
+            rendering = true;
+
+            righting = false;
+            Stereopsis.offsetHudPush(context, false);
+            client.currentScreen.render(context, 0, 0, tickDelta);
+            context.getMatrices().pop();
+
+            righting = true;
+            Stereopsis.offsetHudPush(context, true);
+            client.currentScreen.render(context, 0, 0, tickDelta);
+            context.getMatrices().pop();
+
+            rendering = false;
+            profiler.pop();
+        }
+    }
 }

--- a/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
+++ b/src/main/java/io/github/amelonrind/stereopsis/mixin/MixinInGameHud.java
@@ -207,7 +207,7 @@ public abstract class MixinInGameHud {
     }
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void moveInventory(DrawContext context, net.minecraft.class_9779 tickDelta, CallbackInfo ci) {
+    private void moveInventory(DrawContext context, net.minecraft.class_4587 tickDelta, CallbackInfo ci) {
         if (enabled && client.currentScreen != null) {
             ci.cancel();
             Profiler profiler = Profilers.get();


### PR DESCRIPTION
Add logic to render the inventory UI in stereopsis mode.

* Inject a method to handle rendering the inventory UI in stereopsis mode.
* Cancel the default rendering if stereopsis mode is enabled and the current screen is not null.
* Push the stereopsis offset for the left and right eye views and render the current screen for each.
* Use a profiler to track the stereopsis inventory rendering process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/renorari/Stereopsis/pull/3?shareId=3296a7bd-9a24-49aa-b280-3888adaf7848).